### PR TITLE
refs #3

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -107,7 +107,7 @@ class ProjectsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def project_params
       res = params.require(:project).permit(:name, :description, :is_public, :parent_id, :status)
-      res["github_full_name"] = params["project"]["github_full_name"] if params["project"]["github_full_name"]
+      res["github_full_name"] = params["project"]["github_full_name"].gsub(/ 　/,"") if params["project"]["github_full_name"]
       return res
     end
 

--- a/app/models/project_github.rb
+++ b/app/models/project_github.rb
@@ -5,7 +5,7 @@ class ProjectGithub < Provider
   end
 
   def add_issue(params)
-    fn = self.full_name.split("/")
+    fn = self.full_name.gsub(/  /,"").split("/")
     assignee = nil #TODO 担当者の指定をgithubと動機する機能はまだ未実装
     issue = Provider.github.issues.create(
       fn[0], fn[1],


### PR DESCRIPTION
@kmiyake 下記の２つのタイミングでProjectGithubのfull_nameにおける半角と全角スペースをエスケープするようにしました
（ProjectGithubにはrepositoryのfull_nameだけでなく、のowner.loginとnameも保存するようにしてもいいかもしれない）
・projectにgithub_full_nameを追加する時
・projectのgithub_full_nameを使ってissueを追加する時

下記はgithubにおけるrepositories APIの仕様
http://developer.github.com/v3/repos/
