### PR TITLE
Issueのupdateでエラー

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -49,7 +49,7 @@ class IssuesController < ApplicationController
   def update
     respond_to do |format|
       if @issue.update(issue_params)
-        if @issue.project.github
+        if @issue.project.github && @issue.github
           issue = @issue.github.modify(
             current_user.github.oauth_token, issue_params
           )


### PR DESCRIPTION
元々Github連携されていないissueを更新しようとするとエラーとなるため、updateするissueがGithub連携されているかチェックを追加。

ref #18
