### PR TITLE
プロジェクトへgithubレポジトリを登録する時にレポジトリの妥当性を確認する

### DIFF
--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -7,4 +7,7 @@
     top: 0;
     right: 0;
   }
+  form {
+    margin-bottom: 15px;
+  }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -57,7 +57,7 @@ class ProjectsController < ApplicationController
 
   def update
     respond_to do |format|
-      if @project.modify(project_params)
+      if @project.update(project_params)
         format.html { redirect_to @project, notice: 'Project was successfully updated.' }
         format.json { head :no_content }
       else

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,7 +32,7 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def modify(params)
+  def update(params)
     if params[:github_full_name]
       self.add_github(params[:github_full_name])
       params.delete(:github_full_name)
@@ -41,7 +41,7 @@ class Project < ActiveRecord::Base
       self.add_ruffnote(params[:ruffnote_full_name])
       params.delete(:ruffnote_full_name)
     end
-    self.update(params)
+    super(params)
   end
 
   def github_full_name

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,9 +33,10 @@ class Project < ActiveRecord::Base
   end
 
   def update(params)
-    if params[:github_full_name]
-      self.add_github(params[:github_full_name])
+    if params[:github_full_name] && self.add_github(params[:github_full_name])
       params.delete(:github_full_name)
+    else
+      return false
     end
     if params[:ruffnote_full_name]
       self.add_ruffnote(params[:ruffnote_full_name])
@@ -57,13 +58,29 @@ class Project < ActiveRecord::Base
   end
 
   def add_github(full_name)
-    pg = ProjectGithub.find_or_create_by(
-      name: "github",
-      foreign_id: self.id,
-      provided_type: "Project"
-    )
-    pg.full_name = full_name.gsub(/[[:space:]*]/, "")
-    pg.save
+    admin = User.find(self.members.find_by("is_admin = true").user_id)
+    github = Github.new(oauth_token: admin.github.oauth_token)
+    owner, repo_name = full_name.gsub(/[[:space:]*]/, "").split("/")
+    repo = github.repos.get(owner, repo_name)
+    if repo.present?
+      pg = ProjectGithub.find_or_create_by(
+        name: "github",
+        foreign_id: self.id,
+        provided_type: "Project"
+      )
+      pg.full_name = repo.full_name
+      pg.save
+    end
+  rescue Github::Error::NotFound => e
+    self.errors.add(:base, "#{full_name} is not found.")
+    false
+  rescue ArgumentError => e
+    self.errors.add(:base, "#{full_name} is invalid. Please confirm input parameters.")
+    false
+  rescue => e
+    logger.debug "[ERROR] #{e.class} #{e.message}"
+    self.errors.add(:base, "An unexpected error has occurred. Please confirm input parameters.")
+    false
   end
 
   def ruffnote_full_name

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -16,17 +16,17 @@
     <%= f.text_field :name, class: "form-control", placeholder: "Enter project name" %>
   </div>
   <div class="form-group">
-    <%= f.label :description %><br>
+    <%= f.label :description %> (optional)<br>
     <%= f.text_area :description, class: "form-control" %>
   </div>
   
   <% if @project.persisted? %>
   <div class="form-group">
-    <%= f.label :github_full_name %><br>
-    <%= f.text_field :github_full_name, class: "form-control" %>
+    <%= f.label :github_full_name %> (optional)<br>
+    <%= f.text_field :github_full_name, class: "form-control", placeholder: "rails/rails" %>
   </div>
   <div class="form-group">
-    <%= f.label :ruffnote_full_name %><br>
+    <%= f.label :ruffnote_full_name %> (optional)<br>
     <%= f.text_field :ruffnote_full_name, class: "form-control" %>
   </div>
   <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -4,9 +4,9 @@
       <h2><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
 
       <ul>
-      <% @project.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
+        <% @project.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
       </ul>
     </div>
   <% end %>
@@ -19,8 +19,8 @@
     <%= f.label :description %> (optional)<br>
     <%= f.text_area :description, class: "form-control" %>
   </div>
-  
   <% if @project.persisted? %>
+  <hr>
   <div class="form-group">
     <%= f.label :github_full_name %> (optional)<br>
     <%= f.text_field :github_full_name, class: "form-control", placeholder: "rails/rails" %>
@@ -30,12 +30,24 @@
     <%= f.text_field :ruffnote_full_name, class: "form-control" %>
   </div>
   <% end %>
-
-  <div class="checkbox">
-    <%= f.check_box :is_public %>
-    <%= f.label :is_public %>
+  <hr>
+  <div class="radio">
+    <label>
+      <%= f.radio_button :is_public, "true" %>
+      <b>Public</b><br>
+      <span class="text-muted">Anyone can see this project.</span>
+    </label>
   </div>
+
+  <div class="radio">
+    <label>
+      <%= f.radio_button :is_public, "false" %>
+      <b>Private</b><br>
+      <span class="text-muted">You choose who can see to this project.</span>
+    </label>
+  </div>
+  <hr>
   <div class="actions">
-    <%= f.submit class: "btn btn-default" %>
+    <%= f.submit class: "btn btn-success" %>
   </div>
 <% end %>


### PR DESCRIPTION
今まではGithubに実際にレポジトリが存在するかどうかにかかわらずProjectGithubが作成されていたが、修正後はGithub APIを通じて入力されたレポジトリの妥当性をチェックして作成するようにした。
