### PR TITLE
can?関係のバグ修正

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -7,7 +7,7 @@
       %span.pull-right
         %ul.actions
           %li #{time_ago_in_words(comment.created_at)} ago
-          - if can? :update, comment && @issue.project.status == Project::STATUS_ACTIVE 
+          - if can?(:update, comment) && @issue.project.status == Project::STATUS_ACTIVE
             %li= link_to "Edit", "#", class: "btn btn-default btn-xs js-edit-comment-button", "data-no-turbolink" => "1"
             %li= link_to "&times;".html_safe, comment, class: "close", data: { confirm: "Are you sure?" }, method: :delete
     .comment-content

--- a/app/views/issues/_actions.html.haml
+++ b/app/views/issues/_actions.html.haml
@@ -1,4 +1,4 @@
-- if can? :update, @issue && @issue.project.status == Project::STATUS_ACTIVE
+- if can?(:update, @issue) && @issue.project.status == Project::STATUS_ACTIVE
   .actions
     - if current_user.work_in_progress?(@issue)
       = link_to "Stop", stop_workload_path(current_user.running_workload), class: "btn btn-warning", method: :patch


### PR DESCRIPTION
can?の文法的バグを修正。
同様のバグでコメント出来ない問題が起きていた。

本PRで修正した箇所は、今々何か困ることは無かったようだが、先に修正しておくべきと思われる。
