### PR TITLE
home#indexで表示するチケット数の条件を修正する

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,7 @@ class HomeController < ApplicationController
       @projects = Project.active.select("projects.*, count(issues.id) AS issues_count").
       joins(:issues).
       where("issues.assignee_id = #{current_user.id}").
+      where("issues.status = 1").
       group("projects.id")
     else
       render 'welcome'


### PR DESCRIPTION
fix #153 

現在はログインユーザーがアサインしている全てのチケット数（オープン、クローズに関わらず）を表示しているが、オープンしているチケット数に変更した。
