### PR TITLE
Iss 165 fail tests in other countries

### DIFF
--- a/spec/models/workload_spec.rb
+++ b/spec/models/workload_spec.rb
@@ -2,10 +2,14 @@ require 'spec_helper'
 
 describe Workload do
   describe "#daily" do
+    before :all do
+      @time = Time.zone.local(2014, 02, 01, 21, 0, 0)
+    end
+
     it "returns workloads on the day" do
-      today_workload = create(:workload, start_at: Time.now.utc, end_at: 1.hour.since(Time.now.utc))
-      last_week_workload = create(:workload, start_at: 1.week.ago(Time.now.utc), end_at: 1.week.ago(1.hour.since(Time.now.utc)))
-      expect(Workload.daily(Date.today)).to eq([today_workload])
+      today_workload = create(:workload, start_at: @time, end_at: 1.hour.since(@time))
+      last_week_workload = create(:workload, start_at: 1.week.ago(@time), end_at: 1.week.ago(1.hour.since(@time)))
+      expect(Workload.daily(@time.to_date)).to eq([today_workload])
     end
   end
 end

--- a/spec/models/workload_spec.rb
+++ b/spec/models/workload_spec.rb
@@ -10,6 +10,7 @@ describe Workload do
       today_workload = create(:workload, start_at: @time, end_at: 1.hour.since(@time))
       last_week_workload = create(:workload, start_at: 1.week.ago(@time), end_at: 1.week.ago(1.hour.since(@time)))
       expect(Workload.daily(@time.to_date)).to eq([today_workload])
+      expect(Workload.daily(1.week.ago(@time.to_date))).to eq([last_week_workload])
     end
   end
 end


### PR DESCRIPTION
テストにおいて時刻は固定したほうが良いと思うので、固定しています。
また、Time.newを使うと各自のPCのローカルのタイムゾーンが摘要されてしまうため、
Time.zone.localを利用してconfig.time_zoneのタイムゾーンを利用しています。
