### PR TITLE
Fix bug that occurred crowdworks_url is nil

### DIFF
--- a/app/views/issues/_actions.html.haml
+++ b/app/views/issues/_actions.html.haml
@@ -1,7 +1,7 @@
 - if can?(:update, @issue) && @issue.project.status == Project::STATUS_ACTIVE
   .actions
     - if current_user.work_in_progress?(@issue)
-      - if @project.crowdworks_url.empty? or current_user.authentications.where(provider: "crowdworks").blank?
+      - if @project.crowdworks_url.blank? || current_user.authentications.where(provider: "crowdworks").blank?
         = link_to "Stop", stop_workload_path(current_user.running_workload), class: "btn btn-warning", method: :patch
       - else
         = link_to "Stop", stop_workload_path(current_user.running_workload), class: "btn btn-warning", method: :patch, remote: true, :'data-type' => :html, data: { prompt: { message: "password?\n***It does not save the password.***", default: '', param: 'password'} }

--- a/app/views/issues/_issue.html.haml
+++ b/app/views/issues/_issue.html.haml
@@ -26,7 +26,7 @@
         - else
           = link_to "Do today", do_today_issue_path(issue, format: :json), remote: true, method: :patch, class: "btn btn-default js-hide-issue"
         - if current_user.work_in_progress?(issue)
-          - if issue.project.crowdworks_url.empty? or current_user.authentications.where(provider: "crowdworks").blank?
+          - if issue.project.crowdworks_url.blank? || current_user.authentications.where(provider: "crowdworks").blank?
             = link_to "Stop", stop_workload_path(current_user.running_workload.id), remote: true, method: :patch, class: "btn btn-warning js-stop-workload-button"
           - else
             = link_to "Stop", stop_workload_path(current_user.running_workload.id), remote: true, method: :patch, class: "btn btn-warning js-stop-workload-password-button"


### PR DESCRIPTION
Because default setting of database migrattion is nil.

Therefore it should be use blank? method.
`nil` object is not have empty? method.
