### PR TITLE
Fix bug in SQL statement error

### DIFF
--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -2,8 +2,7 @@ class WorkersController < ApplicationController
   def index
     @workers = User.joins(:workloads).
       where("workloads.end_at IS NULL").
-      order("workloads.start_at ASC").
-      group("users.id")
+      order("workloads.start_at ASC")
 
     respond_to do |format|
       format.json { render 'index', status: :ok }


### PR DESCRIPTION
PG::GroupingError: ERROR:  column "workloads.start_at" must appear
in the GROUP BY clause or be used in an aggregate function
