### PR TITLE
Fix bug of sending notify mail

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -41,7 +41,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           remember_me(user)
           sign_in(:user, user)
           if current_user
-            NotifyMailer.sign_up_user(user).deliver
+            begin
+              NotifyMailer.sign_up_user(user).deliver
+            rescue Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPSyntaxError, Net::SMTPFatalError, Net::SMTPUnknownError => e
+              logger.debug "[#{e.class}] #{e.message}"
+            end
           end
         else
           session[:omniauth] = omniauth.except('extra')

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super
     if current_user
-      NotifyMailer.sign_up_user(current_user).deliver
+      begin
+        NotifyMailer.sign_up_user(current_user).deliver
+      rescue Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPSyntaxError, Net::SMTPFatalError, Net::SMTPUnknownError => e
+        logger.debug "[#{e.class}] #{e.message}"
+      end
     end
   end
 


### PR DESCRIPTION
通知メール送信で不備があった場合に例外エラーでユーザーの処理が阻害され
ないようにする。
