### PR TITLE
Fix bug when reloading page

### DIFF
--- a/app/assets/javascripts/views/comments/list.js.coffee
+++ b/app/assets/javascripts/views/comments/list.js.coffee
@@ -2,7 +2,7 @@ class Timecard.Views.CommentsList extends Backbone.View
 
   template: JST['comments/list']
 
-  el: '.comments'
+  el: '.comments-list__container'
 
   initialize: ->
 

--- a/app/assets/javascripts/views/projects/list.js.coffee
+++ b/app/assets/javascripts/views/projects/list.js.coffee
@@ -2,7 +2,7 @@ class Timecard.Views.ProjectsList extends Backbone.View
 
   template: JST['projects/list']
 
-  el: '.projects'
+  el: '.projects-list__container'
 
   events:
     'click .project-all--link': 'show'

--- a/app/assets/javascripts/views/workers/list.js.coffee
+++ b/app/assets/javascripts/views/workers/list.js.coffee
@@ -2,7 +2,7 @@ class Timecard.Views.WorkersList extends Backbone.View
 
   template: JST['workers/list']
 
-  el: '.workers'
+  el: '.workers-list__container'
   
   events:
     'click .workers-reload': 'reloadWorkersList'

--- a/app/assets/templates/home/sidebar.jst.eco
+++ b/app/assets/templates/home/sidebar.jst.eco
@@ -1,6 +1,6 @@
-<div class="projects">
+<div class="projects-list__container">
 </div>
-<div class="workers">
+<div class="workers-list__container">
 </div>
-<div class="comments">
+<div class="comments-list__container">
 </div>


### PR DESCRIPTION
body要素のクラスに各コントローラー名がセットされるのでリロードしたときに
Backbone.jsのviewによって上書きされてしまう。
