### PR TITLE
Fix bug when stopped timer on global navigation

### DIFF
--- a/app/views/api/_workload.jbuilder
+++ b/app/views/api/_workload.jbuilder
@@ -1,3 +1,5 @@
 json.extract! workload, :id, :start_at, :end_at, :created_at, :updated_at
-json.issue workload.issue
+json.issue do
+  json.partial! "issue", issue: workload.issue
+end
 json.user workload.user


### PR DESCRIPTION
jsonレスポンスのissueレイアウトが指定されていなかったため
クラウドワークス連携されたプロジェクトのチケットと
認識できていなかった。
