### PR TITLE
Fix blocking screen problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'chai-jquery-rails'
   gem 'sinon-rails'
+  gem 'mysql2'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       execjs
     coffee-script-source (1.7.1)
     colorize (0.7.3)
-    coveralls (0.7.0)
+    coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
       simplecov (>= 0.7)
@@ -253,6 +253,7 @@ GEM
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mysql2 (0.3.16)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     netrc (0.7.7)
@@ -408,7 +409,7 @@ GEM
       i18n
     timecop (0.7.1)
     timers (1.1.0)
-    tins (1.3.2)
+    tins (1.3.3)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -474,6 +475,7 @@ DEPENDENCIES
   konacha
   letter_opener (~> 1.2.0)
   mechanize
+  mysql2
   omniauth-github (~> 1.1.1)
   omniauth-ruffnote!
   pg

--- a/app/assets/javascripts/models/workload.js.coffee
+++ b/app/assets/javascripts/models/workload.js.coffee
@@ -34,3 +34,6 @@ class Timecard.Models.Workload extends Backbone.Model
       Date.parse(@get('end_at'))
     else
       new Date()
+
+  isStopped: ->
+    @get('end_at')?

--- a/app/assets/javascripts/views/time_entries/crowdworks_modal.js.coffee
+++ b/app/assets/javascripts/views/time_entries/crowdworks_modal.js.coffee
@@ -16,11 +16,9 @@ class Timecard.Views.TimeEntriesCrowdworksModal extends Backbone.View
     attributes = {end_at: new Date(), password: password}
     if remember_me
       sessionStorage.setItem('crowdworks_password', password)
-    $.blockUI()
     current_entry = @collection.findWhere(end_at: null)
     current_entry.save attributes,
       patch: true
       wait: true
       success: (time_entry) =>
         Timecard.timer.stop()
-        $.unblockUI()

--- a/app/assets/javascripts/views/time_entries/crowdworks_modal.js.coffee
+++ b/app/assets/javascripts/views/time_entries/crowdworks_modal.js.coffee
@@ -10,6 +10,7 @@ class Timecard.Views.TimeEntriesCrowdworksModal extends Backbone.View
 
   addCrowdworksPassword: (e) ->
     e.preventDefault()
+    $('.time-entries__start-button a').text('Sending ...').attr('disabled', 'disabled')
     @$el.modal('hide')
     password = @$('.crowdworks-form__password').val()
     remember_me = @$('.crowdworks-form__remember-me').prop('checked')
@@ -22,3 +23,4 @@ class Timecard.Views.TimeEntriesCrowdworksModal extends Backbone.View
       wait: true
       success: (time_entry) =>
         Timecard.timer.stop()
+      error: (time_entry, response, options) =>

--- a/app/assets/javascripts/views/workloads/crowdworks_modal.js.coffee
+++ b/app/assets/javascripts/views/workloads/crowdworks_modal.js.coffee
@@ -19,7 +19,6 @@ class Timecard.Views.WorkloadsCrowdworksModal extends Backbone.View
     attrs = {end_at: new Date(), password: password}
     if remember_me
       sessionStorage.setItem('crowdworks_password', password)
-    $.blockUI()
     model = @options.workloads.findWhere(end_at: null)
     model.save attrs,
       success: (model) =>
@@ -28,4 +27,3 @@ class Timecard.Views.WorkloadsCrowdworksModal extends Backbone.View
         Timecard.timer.stop()
         $('.timer').removeClass('timer--on')
         $('.timer').addClass('timer--off')
-        $.unblockUI()

--- a/app/assets/javascripts/views/workloads/timer_button.js.coffee
+++ b/app/assets/javascripts/views/workloads/timer_button.js.coffee
@@ -5,8 +5,8 @@ class Timecard.Views.WorkloadsTimerButton extends Backbone.View
   el: '.timer-button__container'
 
   events:
-    'click .timer-button--start': 'startTimer'
-    'click .timer-button--stop': 'stopTimer'
+    'click .timer-button--start': 'start'
+    'click .timer-button--stop': 'stop'
 
   initialize: (@options) ->
     @issue = @options.issue
@@ -15,7 +15,7 @@ class Timecard.Views.WorkloadsTimerButton extends Backbone.View
     @$el.html(@template(issue: @issue))
     @
 
-  startTimer: (e) ->
+  start: (e) ->
     e.preventDefault()
     model = @collection.findWhere(end_at: null)
     if model?
@@ -33,20 +33,20 @@ class Timecard.Views.WorkloadsTimerButton extends Backbone.View
         $('.timer').removeClass('timer--off')
         $('.timer').addClass('timer--on')
 
-  stopTimer: (e) ->
+  stop: (e) ->
     e.preventDefault()
     if @issue.get('is_crowdworks') is true
       password = sessionStorage.getItem('crowdworks_password')
       if password?
         attrs = {end_at: new Date(), password: password}
-        @updateWorkload(attrs)
+        @update(attrs)
       else
         $('.crowdworks-form__modal').modal('show')
     else
       attrs = {end_at: new Date()}
-      @updateWorkload(attrs)
+      @update(attrs)
 
-  updateWorkload: (attrs) ->
+  update: (attrs) ->
     $.blockUI()
     @collection.current_user = true
     @collection.fetch

--- a/app/assets/javascripts/views/workloads/timer_button.js.coffee
+++ b/app/assets/javascripts/views/workloads/timer_button.js.coffee
@@ -47,7 +47,6 @@ class Timecard.Views.WorkloadsTimerButton extends Backbone.View
       @update(attrs)
 
   update: (attrs) ->
-    $.blockUI()
     @collection.current_user = true
     @collection.fetch
       success: (collection) =>
@@ -60,4 +59,3 @@ class Timecard.Views.WorkloadsTimerButton extends Backbone.View
             @issue.set('is_running', false)
             $('.timer').removeClass('timer--on')
             $('.timer').addClass('timer--off')
-            $.unblockUI()

--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -1,11 +1,9 @@
 class WorkloadsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_workload, only: [:edit, :update, :destroy]
+  load_and_authorize_resource :workload, except: [:index, :create]
 
   rescue_from Crowdworks::Error::PasswordNotFound, with: :crowdworks_errors
   rescue_from Crowdworks::Error::LoginFailed, with: :crowdworks_errors
-
-  authorize_resource
 
   def index
     if params[:user_id].present?
@@ -64,10 +62,6 @@ class WorkloadsController < ApplicationController
   end
 
   private
-
-  def set_workload
-    @workload = Workload.find(params[:id])
-  end
 
   def workload_params
     params.require(:workload).permit(:id, :start_at, :end_at, :issue_id, :user_id, :created_at, :updated_at, :password)

--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -74,6 +74,6 @@ class WorkloadsController < ApplicationController
   end
 
   def crowdworks_errors
-    render json: @workload.errors, status: :unprocessable_entity
+    render json: { workload: @workload.to_json, errors: @workload.errors }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -1,6 +1,6 @@
 class WorkloadsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_workload, only: [:edit, :update, :destroy, :stop]
+  before_action :set_workload, only: [:edit, :update, :destroy]
 
   rescue_from Crowdworks::Error::PasswordNotFound, with: :crowdworks_errors
   rescue_from Crowdworks::Error::LoginFailed, with: :crowdworks_errors
@@ -35,15 +35,9 @@ class WorkloadsController < ApplicationController
       Chatwork.post(body)
     end
 
-    respond_to do |format|
-      format.html { redirect_to @issue, notice: 'Work log was successfully started.' }
-      format.json { render action: 'workload' }
-    end
+    render "workload"
   rescue => e
-    respond_to do |format|
-      format.html { redirect_to :back, alert: e.message }
-      format.json { render json: e.message, status: :unprocessable_entity }
-    end
+    render json: { errors: e.message }, status: :unprocessable_entity
   end
 
   def update
@@ -66,19 +60,6 @@ class WorkloadsController < ApplicationController
     respond_to do |format|
       format.html { redirect_to @workload.issue }
       format.json { head :no_content }
-    end
-  end
-
-  def stop
-    respond_to do |format|
-      if @workload.update_attribute(:end_at, Time.now.utc)
-        if current_user.crowdworks && @workload.issue.project.crowdworks_contracts.exists?(["user_id = ?", current_user.id])
-          logging_crowdworks
-        end
-        format.html { redirect_to @workload.issue, notice: 'Work log was successfully stopped.' }
-        format.json { render action: 'stop', status: :created, location: @workload }
-        format.js
-      end
     end
   end
 

--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -1,6 +1,10 @@
 class WorkloadsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_workload, only: [:edit, :update, :destroy, :stop]
+
+  rescue_from Crowdworks::Error::PasswordNotFound, with: :crowdworks_errors
+  rescue_from Crowdworks::Error::LoginFailed, with: :crowdworks_errors
+
   authorize_resource
 
   def index
@@ -55,11 +59,6 @@ class WorkloadsController < ApplicationController
         format.json { render json: @workload.errors, status: :unprocessable_entity }
       end
     end
-  rescue Crowdworks::Error::PasswordNotFound, Crowdworks::Error::LoginFailed => e
-    respond_to do |format|
-      format.html { redirect_to @workload.issue, alert: "Login failed to Crowdworks. Please check your username or password." }
-      format.json { render json: @workload.errors, status: :unprocessable_entity }
-    end
   end
 
   def destroy
@@ -81,11 +80,6 @@ class WorkloadsController < ApplicationController
         format.js
       end
     end
-  rescue Crowdworks::Error::PasswordNotFound, Crowdworks::Error::LoginFailed => e
-    respond_to do |format|
-      format.html { redirect_to @workload.issue, alert: "Login failed to Crowdworks. Please check your username or password." }
-      format.json { render json: @workload.errors, status: :unprocessable_entity }
-    end
   end
 
   private
@@ -102,5 +96,9 @@ class WorkloadsController < ApplicationController
     @crowdworks = Crowdworks.new
     @crowdworks.login(current_user.crowdworks.username, params[:password])
     @crowdworks.submit_timesheet(@workload)
+  end
+
+  def crowdworks_errors
+    render json: @workload.errors, status: :unprocessable_entity
   end
 end

--- a/spec/controllers/workloads_controller_spec.rb
+++ b/spec/controllers/workloads_controller_spec.rb
@@ -51,14 +51,14 @@ describe WorkloadsController do
   describe "POST 'create'" do
     it "creates new workload" do
       expect {
-        post "create", issue_id: @issue, workload: attributes_for(:workload)
+        post "create", format: :json, issue_id: @issue, workload: attributes_for(:workload)
       }.to change(Workload, :count).by(1)
     end
 
     describe "if other issue already running" do
       it "stop previous issue and start new issue" do
         workload = create(:workload, user: @user, issue: @previous_issue, end_at: nil)
-        post 'create', issue_id: @issue, workload: attributes_for(:workload)
+        post 'create', format: :json, issue_id: @issue, workload: attributes_for(:workload)
         workload.reload
         expect(workload.end_at).not_to be_nil
       end
@@ -95,15 +95,6 @@ describe WorkloadsController do
       workload = create(:workload, issue: @issue, user: @user)
       delete 'destroy', id: workload.to_param
       expect(response).to redirect_to workload.issue
-    end
-  end
-
-  describe "PATCH 'stop'" do
-    it "inserts time to end_at" do
-      post 'create', issue_id: @issue, workload: attributes_for(:workload)
-      expect(Workload.last.end_at).to be_nil
-      patch 'stop', id: Workload.last
-      expect(Workload.last.end_at).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
fix #464 

作業ストップ時の画面ブロックを廃止し、以下の様な挙動に変更。
- CW連携していないチケットのストップ時には特別な処理なし
- CW連携しているチケットのストップ時にはボタンを`disabled`にして2度押しを防止する
